### PR TITLE
adding tls 1.1 and 1.2 support

### DIFF
--- a/lib/classes/Swift/Transport/StreamBuffer.php
+++ b/lib/classes/Swift/Transport/StreamBuffer.php
@@ -91,7 +91,7 @@ class Swift_Transport_StreamBuffer extends Swift_ByteStream_AbstractFilterableIn
 
     public function startTLS()
     {
-        return stream_socket_enable_crypto($this->_stream, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+        return stream_socket_enable_crypto($this->_stream, true, STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT | STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
     }
 
     /**


### PR DESCRIPTION
This PR was made only to check the diff between the `tls` and `5.x` branches. The `tls` branch should not be deleted because we are using it in the plugin.